### PR TITLE
CI: Drop 2.3, 2.4 from matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ cache: bundler
 
 matrix:
   include:
-    - rvm: 2.3
-    - rvm: 2.4
     - rvm: 2.5
     - rvm: 2.6
     - rvm: 2.7


### PR DESCRIPTION
See support schedule of Ruby https://www.ruby-lang.org/en/downloads/branches/