### PR TITLE
Fix slot size for non-64bit architectures

### DIFF
--- a/lib/rspec/memory/trace.rb
+++ b/lib/rspec/memory/trace.rb
@@ -23,7 +23,7 @@ require 'objspace'
 module RSpec
 	module Memory
 		Allocation = Struct.new(:count, :size) do
-			SLOT_SIZE = 40
+			SLOT_SIZE = ObjectSpace.memsize_of(Object.new)
 			
 			def << object
 				self.count += 1


### PR DESCRIPTION
## Description

The slot sizes are different per architecture:

amd64:
`ruby -robjspace -e 'puts ObjectSpace.memsize_of(Object.new)'` => 40

armhf:
`ruby -robjspace -e 'puts ObjectSpace.memsize_of(Object.new)'` => 24

i386:
`ruby -robjspace -e 'puts ObjectSpace.memsize_of(Object.new)'` => 20

However, the size in `lib/rspec/memory/trace.rb` is fix with the value of `40`.

This led to test failures, as reported here:
<https://github.com/socketry/async-rspec/issues/16>

### Types of Changes

- Bug fix.

The idea is to expose the slot size dynamically instead of hard-coding it.

### Testing

- [x ] I tested my changes locally.