### PR TITLE
Remove unused rake dependency

### DIFF
--- a/rspec-memory.gemspec
+++ b/rspec-memory.gemspec
@@ -18,5 +18,4 @@ Gem::Specification.new do |spec|
 	
 	spec.add_development_dependency "bundler"
 	spec.add_development_dependency "covered"
-	spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Rakefile was removed but `rake` was left over. I believe it should be removed as well.

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
